### PR TITLE
Makefile: Make CC Configurable And Rework CCFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,24 @@
 ifeq ($(origin CC),default)
 CC=gcc
 endif
-CCFLAGS=-O -g -Wall -std=gnu99 -D_LARGEFILE64_SOURCE
-LIBFLAGS=-O -g -Wall -std=gnu99 -fPIC -c -D_LARGEFILE64_SOURCE
-SHELLFLAGS=-O -g -Wall
+CCFLAGS?=-O -g -Wall -std=gnu99
+LIBFLAGS=$(CCFLAGS) -fPIC -c
 LIBS=-lm -lpthread -lz -lcrypt
 
 all: clean lib shell
 
 lib: src/ldb.c src/mz.c src/ldb.h
-	@$(CC) $(LIBFLAGS) src/ldb.c src/mz.c $(LIBS)
+	@$(CC) $(LIBFLAGS) -D_LARGEFILE64_SOURCE src/ldb.c src/mz.c $(LIBS)
 	@$(CC) -shared -Wl,-soname,libldb.so -o libldb.so ldb.o mz.o $(LIBS)
 	@echo Library is built
 
 shell: src/shell.c src/command.c
-	@$(CC) $(CCFLAGS) $(SHELLFLAGS) -c src/shell.c src/mz.c $(LIBS)
-	@$(CC) $(SHELLFLAGS) -o ldb ldb.o shell.o -lz -lcrypto $(LIBS)
+	@$(CC) $(CCFLAGS) -D_LARGEFILE64_SOURCE -c src/shell.c src/mz.c $(LIBS)
+	@$(CC) $(CCFLAGS) -o ldb ldb.o shell.o -lcrypto $(LIBS)
 	@echo Shell is built
 
 static: src/ldb.c src/ldb.h src/shell.c
-	@$(CC) $(CCFLAGS) $(SHELLFLAGS) -o ldb -O -g -Wall src/ldb.c src/ldb.h src/shell.c src/mz.c $(LIBS)
+	@$(CC) $(CCFLAGS) -o ldb src/ldb.c src/ldb.h src/shell.c src/mz.c $(LIBS)
 	@echo Shell is built
 
 distclean: clean

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
+ifeq ($(origin CC),default)
 CC=gcc
+endif
 CCFLAGS=-O -g -Wall -std=gnu99 -D_LARGEFILE64_SOURCE
 LIBFLAGS=-O -g -Wall -std=gnu99 -fPIC -c -D_LARGEFILE64_SOURCE
 SHELLFLAGS=-O -g -Wall


### PR DESCRIPTION
Make CC variable and therefore the compiler configurable by checking if
it is set already by using the origin function.
This is helpful to change the compiler version on the fly or to use a
specific compiler for a different platform.

Make CCFLAGS respect predefined flags.
Move large file define into affected places instead of keeping it in the flags.
Remove SHELLFLAGS as they are redundant.
Remove hard coded flags in static section as they are redundant as well.
Remove zlib in shell section as it is redundant.