### PR TITLE
LDB hex print minor upgrade

### DIFF
--- a/src/ldb.c
+++ b/src/ldb.c
@@ -79,7 +79,7 @@ char *ldb_commands[] =
 	"version",
 	"unlink list from {ascii} key {hex}",
 	"dump {ascii} hex {ascii} sector {hex}",
-	"dump {ascii} hex {ascii}",
+	"dump {ascii} hex {ascii}, use 'hex -1' to print the complete register as hex",
 	"dump keys from {ascii}",
 	"cat {hex} from {ascii}"
 };

--- a/src/ldb.h
+++ b/src/ldb.h
@@ -36,7 +36,7 @@
 #include <unistd.h>
 #include <openssl/md5.h>
 
-#define LDB_VERSION "3.1.3"
+#define LDB_VERSION "3.1.4"
 #define LDB_MAX_PATH 1024
 #define LDB_MAX_NAME 64
 #define LDB_MAX_RECORDS 500000 // Max number of records per list

--- a/src/string.c
+++ b/src/string.c
@@ -150,8 +150,14 @@ bool ldb_csvprint(uint8_t *key, uint8_t *subkey, int subkey_ln, uint8_t *data, u
 
 	/* Print remaining hex bytes (if any, as a second CSV field) */
 	int *hex_bytes = ptr;
-	int remaining_hex = *hex_bytes - LDB_KEY_LN - subkey_ln;
+	int remaining_hex = 0;
+	if (*hex_bytes < 0)
+		remaining_hex = size - LDB_KEY_LN - subkey_ln;
+	else
+	 	remaining_hex = *hex_bytes - LDB_KEY_LN - subkey_ln;
+
 	if (remaining_hex < 0) remaining_hex = 0;
+	
 	if (remaining_hex)
 	{
 		printf(",");

--- a/src/string.c
+++ b/src/string.c
@@ -152,7 +152,7 @@ bool ldb_csvprint(uint8_t *key, uint8_t *subkey, int subkey_ln, uint8_t *data, u
 	int *hex_bytes = ptr;
 	int remaining_hex = 0;
 	if (*hex_bytes < 0)
-		remaining_hex = size - LDB_KEY_LN - subkey_ln;
+		remaining_hex = size;
 	else
 	 	remaining_hex = *hex_bytes - LDB_KEY_LN - subkey_ln;
 


### PR DESCRIPTION
use hex -1 to print the complete register content as hex.