### PR TITLE
[unexpected error] fix the bug about data loss during data importation

### DIFF
--- a/src/import.c
+++ b/src/import.c
@@ -749,7 +749,7 @@ int ldb_import_csv(ldb_importation_config_t * job)
 					}
 				}
 				/* Open new sector if needed */
-				if (*itemid != *item_lastid)
+				if (*itemid != *item_lastid || || (*itemid == 0 && !item_ptr))
 				{
 					if (item_sector)
 						ldb_close_unlock(item_sector);


### PR DESCRIPTION
https://github.com/scanoss/ldb/issues/17
The first data in mined/file/00.csv will be overwritten by the next data